### PR TITLE
Remove `python_2_unicode_compatible`

### DIFF
--- a/django_comments/abstracts.py
+++ b/django_comments/abstracts.py
@@ -6,7 +6,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 try:
     from django.urls import reverse
@@ -48,7 +47,6 @@ class BaseCommentAbstractModel(models.Model):
         )
 
 
-@python_2_unicode_compatible
 class CommentAbstractModel(BaseCommentAbstractModel):
     """
     A user comment about some object.

--- a/django_comments/models.py
+++ b/django_comments/models.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from .abstracts import (
@@ -17,7 +16,6 @@ class Comment(CommentAbstractModel):
         ]
 
 
-@python_2_unicode_compatible
 class CommentFlag(models.Model):
     """
     Records a flag on a comment. This is intentionally flexible; right now, a

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -6,10 +6,8 @@ more information.
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class Author(models.Model):
     first_name = models.CharField(max_length=30)
     last_name = models.CharField(max_length=30)
@@ -18,7 +16,6 @@ class Author(models.Model):
         return '%s %s' % (self.first_name, self.last_name)
 
 
-@python_2_unicode_compatible
 class Article(models.Model):
     author = models.ForeignKey(Author, on_delete=models.CASCADE)
     headline = models.CharField(max_length=100)
@@ -27,7 +24,6 @@ class Article(models.Model):
         return self.headline
 
 
-@python_2_unicode_compatible
 class Entry(models.Model):
     title = models.CharField(max_length=250)
     body = models.TextField()


### PR DESCRIPTION
Removed the import and usage of the `python_2_unicode_compatible`
decorator which is removed in Django 3.