### PR TITLE
[INT-1474] Resolve remaining Django 4.x compatibility issues

### DIFF
--- a/django_comments/forms.py
+++ b/django_comments/forms.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.forms.utils import ErrorDict
 from django.utils.crypto import salted_hmac, constant_time_compare
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import get_text_list
 from django.utils import timezone
 from django.utils.translation import pgettext_lazy, ngettext, gettext, gettext_lazy as _
@@ -139,7 +139,7 @@ class CommentDetailsForm(CommentSecurityForm):
         """
         return dict(
             content_type=ContentType.objects.get_for_model(self.target_object),
-            object_pk=force_text(self.target_object._get_pk_val()),
+            object_pk=force_str(self.target_object._get_pk_val()),
             user_name=self.cleaned_data["name"],
             user_email=self.cleaned_data["email"],
             user_url=self.cleaned_data["url"],

--- a/django_comments/managers.py
+++ b/django_comments/managers.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 class CommentManager(models.Manager):
@@ -18,5 +18,5 @@ class CommentManager(models.Manager):
         ct = ContentType.objects.get_for_model(model)
         qs = self.get_queryset().filter(content_type=ct)
         if isinstance(model, models.Model):
-            qs = qs.filter(object_pk=force_text(model._get_pk_val()))
+            qs = qs.filter(object_pk=force_str(model._get_pk_val()))
         return qs

--- a/django_comments/templatetags/comments.py
+++ b/django_comments/templatetags/comments.py
@@ -3,7 +3,7 @@ from django.template.loader import render_to_string
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 import django_comments
 
@@ -85,7 +85,7 @@ class BaseCommentNode(template.Node):
 
         qs = self.comment_model.objects.filter(
             content_type=ctype,
-            object_pk=smart_text(object_pk),
+            object_pk=smart_str(object_pk),
             site__pk=site_id,
         )
 


### PR DESCRIPTION
## Jira Issue
[Resolve remaining compatibility issues with `django-contrib-comments`](https://procurifyteam.atlassian.net/browse/INT-1474)

## Description
There were some remaining uses of deprecated Django methods, namely `force_text` and `smart_text` that were not addressed in the previous patch to make the library fork compatible with Django 4.2. Updated these remaining uses for compatibility.